### PR TITLE
Add Ethos search page and API helper

### DIFF
--- a/lib/ethos.js
+++ b/lib/ethos.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+/**
+ * Fetch Ethos user data by Twitter handle.
+ * @param {string} handle Twitter handle without @
+ * @returns {Promise<Object|null>} The user data or null if not found.
+ */
+export async function fetchUserByTwitter(handle) {
+  try {
+    const url = `https://api.ethos.network/api/v2/user/by/x/${encodeURIComponent(handle)}`;
+    const res = await axios.get(url);
+    if (res.status === 200) {
+      return res.data;
+    }
+    return null;
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add `fetchUserByTwitter` helper for fetching user details
- implement new `pages/index.js` with simple Ethos search UI
- style profile card with styled‑JSX

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b3ea2a9e48321b741dda8bc63db7b