### PR TITLE
Refactor API parsing in EthosProfileCard

### DIFF
--- a/components/EthosProfileCard.jsx
+++ b/components/EthosProfileCard.jsx
@@ -55,11 +55,8 @@ export default function EthosProfileCard() {
         `https://api.ethos.network/api/v1/addresses/profileId:${profileId}`
       );
       if (!addrRes.ok) throw new Error(`Address lookup failed (${addrRes.status})`);
-      const addrJson = await addrRes.json();
-      const primaryAddress =
-        Array.isArray(addrJson.data) && addrJson.data[0]?.address
-          ? addrJson.data[0].address
-          : 'N/A';
+      const { data: addrList } = await addrRes.json();
+      const address = addrList[0]?.address ?? 'N/A';
       setProgress(55);
 
       // 3) v1: ETH price
@@ -68,7 +65,7 @@ export default function EthosProfileCard() {
       );
       if (!priceRes.ok) throw new Error(`Price lookup failed (${priceRes.status})`);
       const {
-        data: { price: ethPrice }
+        data: { price: ethPrice } = {}
       } = await priceRes.json();
       setProgress(70);
 
@@ -118,7 +115,7 @@ export default function EthosProfileCard() {
         vouchesGivenEth,
         vouchesReceived,
         vouchesReceivedEth,
-        primaryAddress,
+        address,
         ethPrice,
         totalVouchedEth
       });
@@ -200,7 +197,7 @@ export default function EthosProfileCard() {
           </Section>
 
           <Section title="On-Chain">
-            <Row label="Primary Address" value={data.primaryAddress} />
+            <Row label="Primary Address" value={data.address} />
             <Row
               label="ETH Price"
               value={data.ethPrice ? `$${Number(data.ethPrice).toFixed(2)}` : 'N/A'}


### PR DESCRIPTION
## Summary
- Simplify v1 API responses to read data from `data` property
- Store address and ETH price in state using new destructured variables
- Display primary address with updated state property

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68904022f5d483219e17c9a4dd32bad8