### PR TITLE
Rewrite profile card to show v2 stats

### DIFF
--- a/components/EthosProfileCard.jsx
+++ b/components/EthosProfileCard.jsx
@@ -3,7 +3,6 @@ import styles from './EthosProfileCard.module.css';
 
 export default function EthosProfileCard() {
   const [handle, setHandle] = useState('');
-  const [searched, setSearched] = useState('');
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [data, setData] = useState(null);
@@ -12,115 +11,52 @@ export default function EthosProfileCard() {
   const toEth = (wei) => (Number(wei) / 1e18).toFixed(3);
 
   const handleSearch = async () => {
-    const username = handle.trim().replace(/^@/, '');
-    if (!username) return;
+    const input = handle.trim().replace(/^@/, '');
+    if (!input) return;
 
     setError('');
-    setSearched(username);
     setData(null);
     setLoading(true);
     setProgress(0);
 
     try {
-      // 1) v2: user lookup by X handle
       const userRes = await fetch(
-        `https://api.ethos.network/api/v2/user/by/x/${username}`
+        `https://api.ethos.network/api/v2/user/by/x/${input}`
       );
       if (!userRes.ok) throw new Error(`User lookup failed (${userRes.status})`);
-      const userJson = await userRes.json();
-      setProgress(20);
-
       const {
         id,
         profileId,
-        avatarUrl: avatar,
-        status,
-        score,
-        xpTotal,
-        xpStreakDays,
+        displayName,
+        username,
+        avatarUrl,
         stats: {
-          review: { received: reviewStats = {} } = {},
+          review: { received: { positive = 0, neutral = 0, negative = 0 } = {} } = {},
           vouch: {
-            given: { count: vouchesGiven = 0, amountWeiTotal: givenWei = '0' } = {},
-            received: { count: vouchesReceived = 0, amountWeiTotal: receivedWei = '0' } = {}
+            given: { count: givenCount = 0, amountWeiTotal: givenWei = '0' } = {},
+            received: { count: receivedCount = 0, amountWeiTotal: receivedWei = '0' } = {}
           } = {}
         } = {}
-      } = userJson;
-      const vouchesGivenEth = toEth(givenWei);
-      const vouchesReceivedEth = toEth(receivedWei);
-      setProgress(40);
+      } = await userRes.json();
+      setProgress(50);
 
-      // 2) v1: get on-chain addresses
-      const addrRes = await fetch(
-        `https://api.ethos.network/api/v1/addresses/profileId:${profileId}`
-      );
-      if (!addrRes.ok) throw new Error(`Address lookup failed (${addrRes.status})`);
-      const addrJson = await addrRes.json();
-      const primaryAddress =
-        Array.isArray(addrJson.data) && addrJson.data[0]?.address
-          ? addrJson.data[0].address
-          : 'N/A';
-      setProgress(55);
-
-      // 3) v1: ETH price
       const priceRes = await fetch(
-        `https://api.ethos.network/api/v1/exchange-rates/eth-price`
+        'https://api.ethos.network/api/v1/exchange-rates/eth-price'
       );
       if (!priceRes.ok) throw new Error(`Price lookup failed (${priceRes.status})`);
-      const {
-        data: { price: ethPrice }
-      } = await priceRes.json();
-      setProgress(70);
-
-      // 4) v1: reviews count
-      const revRes = await fetch(
-        `https://api.ethos.network/api/v1/reviews/count`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ subject: [`profileId:${profileId}`] })
-        }
-      );
-      if (!revRes.ok) throw new Error(`Review count failed (${revRes.status})`);
-      const {
-        data: { count: reviewsCount }
-      } = await revRes.json();
-      setProgress(85);
-
-      // 5) v1: total vouch ETH
-      const vouchedRes = await fetch(
-        `https://api.ethos.network/api/v1/vouches/vouched-ethereum`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ target: `profileId:${profileId}` })
-        }
-      );
-      if (!vouchedRes.ok)
-        throw new Error(`Vouched ETH lookup failed (${vouchedRes.status})`);
-      const {
-        data: { vouchedEth: totalVouchedEth }
-      } = await vouchedRes.json();
+      const { data: { price: ethPrice } = {} } = await priceRes.json();
       setProgress(100);
 
-      // 6) commit to state
       setData({
         id,
         profileId,
-        avatar,
-        status,
-        score,
-        xpTotal,
-        xpStreakDays,
-        reviewStats,
-        reviewsCount,
-        vouchesGiven,
-        vouchesGivenEth,
-        vouchesReceived,
-        vouchesReceivedEth,
-        primaryAddress,
-        ethPrice,
-        totalVouchedEth
+        displayName,
+        username,
+        avatarUrl,
+        reviewStats: { positive, neutral, negative },
+        vouchGiven: { count: givenCount, eth: toEth(givenWei) },
+        vouchReceived: { count: receivedCount, eth: toEth(receivedWei) },
+        ethPrice
       });
     } catch (err) {
       console.error(err);
@@ -161,53 +97,33 @@ export default function EthosProfileCard() {
       {data && (
         <div className={styles.card}>
           <div className={styles.header}>
-            {data.avatar && (
-              <img className={styles.avatar} src={data.avatar} alt="" />
-            )}
+            <img src={data.avatarUrl} alt="" className={styles.avatar} />
             <div>
-              <h2>{searched}</h2>
-              <div className={styles.handle}>@{searched}</div>
+              <h2>{data.displayName}</h2>
+              <div className={styles.handle}>@{data.username}</div>
             </div>
           </div>
 
-          <Section title="Main Stats">
-            <Row label="ID" value={data.id} />
-            <Row label="Profile ID" value={data.profileId} />
-            <Row label="Status" value={data.status} />
-            <Row label="Score" value={data.score} />
-            <Row label="XP Total" value={data.xpTotal} />
-            <Row label="XP Streak Days" value={data.xpStreakDays} />
-          </Section>
-
           <Section title="Reviews Received">
-            <Row
-              label="Total Reviews"
-              value={data.reviewsCount ?? 0}
-            />
+            <Row label="Positive" value={data.reviewStats.positive} />
+            <Row label="Neutral" value={data.reviewStats.neutral} />
+            <Row label="Negative" value={data.reviewStats.negative} />
           </Section>
 
           <Section title="Vouches Given">
-            <Row label="Count" value={data.vouchesGiven} />
-            <Row label="Total ETH" value={`${data.vouchesGivenEth} ETH`} />
+            <Row label="Count" value={data.vouchGiven.count} />
+            <Row label="Total ETH" value={`${data.vouchGiven.eth} ETH`} />
           </Section>
 
           <Section title="Vouches Received">
-            <Row label="Count" value={data.vouchesReceived} />
-            <Row
-              label="Total ETH"
-              value={`${data.vouchesReceivedEth} ETH`}
-            />
+            <Row label="Count" value={data.vouchReceived.count} />
+            <Row label="Total ETH" value={`${data.vouchReceived.eth} ETH`} />
           </Section>
 
           <Section title="On-Chain">
-            <Row label="Primary Address" value={data.primaryAddress} />
             <Row
               label="ETH Price"
-              value={data.ethPrice ? `$${Number(data.ethPrice).toFixed(2)}` : 'N/A'}
-            />
-            <Row
-              label="Total Vouched ETH"
-              value={`${data.totalVouchedEth ?? 0} ETH`}
+              value={`$${Number(data.ethPrice).toFixed(2)}`}
             />
           </Section>
         </div>


### PR DESCRIPTION
## Summary
- query v2 user endpoint and map reviews/vouches into structured state
- render avatar, names, review counts, vouch totals and ETH price

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68904022f5d483219e17c9a4dd32bad8