### PR TITLE
Rewrite profile card to show v2 stats

### DIFF
--- a/components/EthosProfileCard.jsx
+++ b/components/EthosProfileCard.jsx
@@ -3,7 +3,6 @@ import styles from './EthosProfileCard.module.css';
 
 export default function EthosProfileCard() {
   const [handle, setHandle] = useState('');
-  const [searched, setSearched] = useState('');
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [data, setData] = useState(null);
@@ -12,115 +11,52 @@ export default function EthosProfileCard() {
   const toEth = (wei) => (Number(wei) / 1e18).toFixed(3);
 
   const handleSearch = async () => {
-    const username = handle.trim().replace(/^@/, '');
-    if (!username) return;
+    const input = handle.trim().replace(/^@/, '');
+    if (!input) return;
 
     setError('');
-    setSearched(username);
     setData(null);
     setLoading(true);
     setProgress(0);
 
     try {
-      // 1) v2: user lookup by X handle
       const userRes = await fetch(
-        `https://api.ethos.network/api/v2/user/by/x/${username}`
+        `https://api.ethos.network/api/v2/user/by/x/${input}`
       );
       if (!userRes.ok) throw new Error(`User lookup failed (${userRes.status})`);
-      const userJson = await userRes.json();
-      setProgress(20);
-
       const {
         id,
         profileId,
-        avatarUrl: avatar,
-        status,
-        score,
-        xpTotal,
-        xpStreakDays,
+        displayName,
+        username,
+        avatarUrl,
         stats: {
-          review: { received: reviewStats = {} } = {},
+          review: { received: { positive = 0, neutral = 0, negative = 0 } = {} } = {},
           vouch: {
-            given: { count: vouchesGiven = 0, amountWeiTotal: givenWei = '0' } = {},
-            received: { count: vouchesReceived = 0, amountWeiTotal: receivedWei = '0' } = {}
+            given: { count: givenCount = 0, amountWeiTotal: givenWei = '0' } = {},
+            received: { count: receivedCount = 0, amountWeiTotal: receivedWei = '0' } = {}
           } = {}
         } = {}
-      } = userJson;
-      const vouchesGivenEth = toEth(givenWei);
-      const vouchesReceivedEth = toEth(receivedWei);
-      setProgress(40);
+      } = await userRes.json();
+      setProgress(50);
 
-      // 2) v1: get on-chain addresses
-      const addrRes = await fetch(
-        `https://api.ethos.network/api/v1/addresses/profileId:${profileId}`
-      );
-      if (!addrRes.ok) throw new Error(`Address lookup failed (${addrRes.status})`);
-      const addrJson = await addrRes.json();
-      const primaryAddress =
-        Array.isArray(addrJson.data) && addrJson.data[0]?.address
-          ? addrJson.data[0].address
-          : 'N/A';
-      setProgress(55);
-
-      // 3) v1: ETH price
       const priceRes = await fetch(
-        `https://api.ethos.network/api/v1/exchange-rates/eth-price`
+        'https://api.ethos.network/api/v1/exchange-rates/eth-price'
       );
       if (!priceRes.ok) throw new Error(`Price lookup failed (${priceRes.status})`);
-      const {
-        data: { price: ethPrice }
-      } = await priceRes.json();
-      setProgress(70);
-
-      // 4) v1: reviews count
-      const revRes = await fetch(
-        `https://api.ethos.network/api/v1/reviews/count`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ subject: [`profileId:${profileId}`] })
-        }
-      );
-      if (!revRes.ok) throw new Error(`Review count failed (${revRes.status})`);
-      const {
-        data: { count: reviewsCount }
-      } = await revRes.json();
-      setProgress(85);
-
-      // 5) v1: total vouch ETH
-      const vouchedRes = await fetch(
-        `https://api.ethos.network/api/v1/vouches/vouched-ethereum`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ target: `profileId:${profileId}` })
-        }
-      );
-      if (!vouchedRes.ok)
-        throw new Error(`Vouched ETH lookup failed (${vouchedRes.status})`);
-      const {
-        data: { vouchedEth: totalVouchedEth }
-      } = await vouchedRes.json();
+      const { data: { price: ethPrice } = {} } = await priceRes.json();
       setProgress(100);
 
-      // 6) commit to state
       setData({
         id,
         profileId,
-        avatar,
-        status,
-        score,
-        xpTotal,
-        xpStreakDays,
-        reviewStats,
-        reviewsCount,
-        vouchesGiven,
-        vouchesGivenEth,
-        vouchesReceived,
-        vouchesReceivedEth,
-        primaryAddress,
-        ethPrice,
-        totalVouchedEth
+        displayName,
+        username,
+        avatarUrl,
+        reviewStats: { positive, neutral, negative },
+        vouchGiven: { count: givenCount, eth: toEth(givenWei) },
+        vouchReceived: { count: receivedCount, eth: toEth(receivedWei) },
+        ethPrice
       });
     } catch (err) {
       console.error(err);
@@ -161,53 +97,33 @@ export default function EthosProfileCard() {
       {data && (
         <div className={styles.card}>
           <div className={styles.header}>
-            {data.avatar && (
-              <img className={styles.avatar} src={data.avatar} alt="" />
-            )}
+            <img src={data.avatarUrl} alt="" className={styles.avatar} />
             <div>
-              <h2>{searched}</h2>
-              <div className={styles.handle}>@{searched}</div>
+              <h2>{data.displayName}</h2>
+              <div className={styles.handle}>@{data.username}</div>
             </div>
           </div>
 
-          <Section title="Main Stats">
-            <Row label="ID" value={data.id} />
-            <Row label="Profile ID" value={data.profileId} />
-            <Row label="Status" value={data.status} />
-            <Row label="Score" value={data.score} />
-            <Row label="XP Total" value={data.xpTotal} />
-            <Row label="XP Streak Days" value={data.xpStreakDays} />
-          </Section>
-
           <Section title="Reviews Received">
-            <Row
-              label="Total Reviews"
-              value={data.reviewsCount ?? 0}
-            />
+            <Row label="Positive" value={data.reviewStats.positive} />
+            <Row label="Neutral" value={data.reviewStats.neutral} />
+            <Row label="Negative" value={data.reviewStats.negative} />
           </Section>
 
           <Section title="Vouches Given">
-            <Row label="Count" value={data.vouchesGiven} />
-            <Row label="Total ETH" value={`${data.vouchesGivenEth} ETH`} />
+            <Row label="Count" value={data.vouchGiven.count} />
+            <Row label="Total ETH" value={`${data.vouchGiven.eth} ETH`} />
           </Section>
 
           <Section title="Vouches Received">
-            <Row label="Count" value={data.vouchesReceived} />
-            <Row
-              label="Total ETH"
-              value={`${data.vouchesReceivedEth} ETH`}
-            />
+            <Row label="Count" value={data.vouchReceived.count} />
+            <Row label="Total ETH" value={`${data.vouchReceived.eth} ETH`} />
           </Section>
 
           <Section title="On-Chain">
-            <Row label="Primary Address" value={data.primaryAddress} />
             <Row
               label="ETH Price"
-              value={data.ethPrice ? `$${Number(data.ethPrice).toFixed(2)}` : 'N/A'}
-            />
-            <Row
-              label="Total Vouched ETH"
-              value={`${data.totalVouchedEth ?? 0} ETH`}
+              value={`$${Number(data.ethPrice).toFixed(2)}`}
             />
           </Section>
         </div>

--- a/lib/ethos.js
+++ b/lib/ethos.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+// Utility helpers for Ethos API calls using fetch.
 
 /**
  * Fetch Ethos user data by Twitter handle.
@@ -7,14 +7,17 @@ import axios from 'axios';
  */
 export async function fetchUserByTwitter(handle) {
   try {
-    const url = `https://api.ethos.network/api/v2/user/by/x/${encodeURIComponent(handle)}`;
-    const res = await axios.get(url);
-    return res.data;
+    const url = `https://api.ethos.network/api/v2/user/by/x/${encodeURIComponent(
+      handle
+    )}`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const json = await res.json();
+    console.log('fetchUserByTwitter:', json);
+    return json;
   } catch (err) {
-    if (err.response && err.response.status === 404) {
-      return null;
-    }
-    throw err;
+    console.error('fetchUserByTwitter error:', err);
+    return null;
   }
 }
 
@@ -24,9 +27,15 @@ export async function fetchUserByTwitter(handle) {
  */
 export async function fetchExchangeRate() {
   try {
-    const res = await axios.get('https://api.ethos.network/api/v1/exchange-rates/eth-price');
-    return res.data?.price ?? null;
-  } catch {
+    const res = await fetch(
+      'https://api.ethos.network/api/v1/exchange-rates/eth-price'
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    console.log('fetchExchangeRate:', json);
+    return json?.data?.price ?? null;
+  } catch (err) {
+    console.error('fetchExchangeRate error:', err);
     return null;
   }
 }
@@ -38,10 +47,16 @@ export async function fetchExchangeRate() {
  */
 export async function fetchUserAddresses(profileId) {
   try {
-    const url = `https://api.ethos.network/api/v1/addresses/profileId:${encodeURIComponent(profileId)}`;
-    const res = await axios.get(url);
-    return Array.isArray(res.data) ? res.data : [];
-  } catch {
+    const url = `https://api.ethos.network/api/v1/addresses/profileId:${encodeURIComponent(
+      profileId
+    )}`;
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const json = await res.json();
+    console.log('fetchUserAddresses:', json);
+    return Array.isArray(json?.data) ? json.data : [];
+  } catch (err) {
+    console.error('fetchUserAddresses error:', err);
     return [];
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,28 +12,30 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  const xpTotal = userData?.xpTotal ?? userData?.xp?.total ?? 0;
+  const xpStreakDays = userData?.xpStreakDays ?? userData?.xp?.streakDays ?? 0;
+  const vouchReceived =
+    userData?.stats?.vouch?.received ?? { count: 0, amountWeiTotal: '0' };
+
   const handleSearch = async () => {
     if (!username) return;
     setLoading(true);
     setError(null);
     setUserData(null);
     try {
-      // 1) Look up the user via the v2 API
-      const user = await fetchUserByTwitter(username.trim());
-      if (!user) {
+      const data = await fetchUserByTwitter(username.trim());
+      if (!data) {
         setError('User not found');
         return;
       }
-
-      // 2) Fetch addresses and exchange rate in parallel
+      console.log('v2 user:', data);
       const [addresses, ethPrice] = await Promise.all([
-        fetchUserAddresses(user.profileId),
+        fetchUserAddresses(data.profileId),
         fetchExchangeRate(),
       ]);
-
-      // 3) Combine into one object so the card renders once
+      console.log('v1 addresses:', addresses, 'ethPrice:', ethPrice);
       setUserData({
-        ...user,
+        ...data,
         addresses,
         ethPrice,
       });
@@ -46,13 +48,7 @@ export default function Home() {
 
   const formatWeiToEth = (wei) => (Number(wei) / 1e18).toFixed(3);
 
-  const reviewReceived = userData?.stats?.review?.received;
-  const reviewMade = userData?.stats?.review?.made;
-  const vouchGiven = userData?.stats?.vouch?.given;
-  const vouchReceived = userData?.stats?.vouch?.received;
-  const xpTotal = userData?.xpTotal ?? userData?.xp?.total ?? userData?.xp_total;
-  const xpStreakDays =
-    userData?.xpStreakDays ?? userData?.xp?.streakDays ?? userData?.xp_streakDays;
+  console.log(userData);
 
   return (
     <div className={styles.container}>
@@ -76,13 +72,9 @@ export default function Home() {
       {error && <div className={styles.error}>{error}</div>}
       {userData && (
         <div className={styles.userCard}>
-          <div className={styles.header}>
-            <img src={userData.avatarUrl} alt="avatar" className={styles.avatar} />
-            <div>
-              <div className={styles.name}>{userData.displayName}</div>
-              <div className={styles.handle}>@{userData.username}</div>
-            </div>
-          </div>
+          <img src={userData.avatarUrl} alt="" className={styles.avatar} />
+          <h2 className={styles.name}>{userData.displayName}</h2>
+          <p className={styles.handle}>@{userData.username}</p>
 
           <div className={styles.subContainer}>
             <div className={styles.sectionTitle}>Main Stats</div>
@@ -93,79 +85,74 @@ export default function Home() {
               <dt>Score</dt><dd>{userData.score}</dd>
               <dt>XP Total</dt><dd>{xpTotal}</dd>
               <dt>XP Streak Days</dt><dd>{xpStreakDays}</dd>
-              {userData.ethPrice !== null && (
-                <>
-                  <dt>ETH Price (USD)</dt>
-                  <dd>${Number(userData.ethPrice).toFixed(2)}</dd>
-                </>
-              )}
             </dl>
           </div>
 
-          {userData.addresses?.length > 0 && (
-            <div className={styles.subContainer}>
-              <div className={styles.sectionTitle}>Address</div>
-              <dl className={styles.dl}>
-                <dt>Primary Address</dt>
-                <dd>{userData.addresses[0]?.address}</dd>
-              </dl>
-            </div>
-          )}
+          <Section title="Reviews Received">
+            <Row
+              label="Positive"
+              value={userData.stats.review.received.positive}
+            />
+            <Row
+              label="Neutral"
+              value={userData.stats.review.received.neutral}
+            />
+            <Row
+              label="Negative"
+              value={userData.stats.review.received.negative}
+            />
+          </Section>
 
+          <Section title="Vouches Given">
+            <Row label="Count" value={userData.stats.vouch.given.count} />
+            <Row
+              label="Total ETH"
+              value={`${formatWeiToEth(
+                userData.stats.vouch.given.amountWeiTotal
+              )} ETH`}
+            />
+          </Section>
 
-          {reviewReceived && (
-            <div className={styles.subContainer}>
-              <div className={styles.sectionTitle}>Reviews Received</div>
-              <dl className={styles.dl}>
-                <dt>Positive</dt>
-                <dd>{reviewReceived.positive?.count ?? 0}</dd>
-                <dt>Neutral</dt>
-                <dd>{reviewReceived.neutral?.count ?? 0}</dd>
-                <dt>Negative</dt>
-                <dd>{reviewReceived.negative?.count ?? 0}</dd>
-              </dl>
-            </div>
-          )}
+          <div className={styles.subContainer}>
+            <div className={styles.sectionTitle}>Vouches Received</div>
+            <dl className={styles.dl}>
+              <dt>Count</dt>
+              <dd>{vouchReceived.count}</dd>
+              <dt>Total ETH</dt>
+              <dd>{formatWeiToEth(vouchReceived.amountWeiTotal)} ETH</dd>
+            </dl>
+          </div>
 
-          {reviewMade && (
-            <div className={styles.subContainer}>
-              <div className={styles.sectionTitle}>Reviews Made</div>
-              <dl className={styles.dl}>
-                <dt>Positive</dt>
-                <dd>{reviewMade.positive?.count ?? 0}</dd>
-                <dt>Neutral</dt>
-                <dd>{reviewMade.neutral?.count ?? 0}</dd>
-                <dt>Negative</dt>
-                <dd>{reviewMade.negative?.count ?? 0}</dd>
-              </dl>
-            </div>
-          )}
-
-          {vouchGiven && (
-            <div className={styles.subContainer}>
-              <div className={styles.sectionTitle}>Vouches Given</div>
-              <dl className={styles.dl}>
-                <dt>Count</dt>
-                <dd>{vouchGiven.count ?? 0}</dd>
-                <dt>Total ETH</dt>
-                <dd>{formatWeiToEth(vouchGiven.amountWeiTotal ?? 0)} ETH</dd>
-              </dl>
-            </div>
-          )}
-
-          {vouchReceived && (
-            <div className={styles.subContainer}>
-              <div className={styles.sectionTitle}>Vouches Received</div>
-              <dl className={styles.dl}>
-                <dt>Count</dt>
-                <dd>{vouchReceived.count ?? 0}</dd>
-                <dt>Total ETH</dt>
-                <dd>{formatWeiToEth(vouchReceived.amountWeiTotal ?? 0)} ETH</dd>
-              </dl>
-            </div>
-          )}
+          <Section title="On-Chain">
+            <Row
+              label="Primary Address"
+              value={userData.addresses[0]?.address ?? 'N/A'}
+            />
+            <Row
+              label="ETH Price (USD)"
+              value={`$${userData.ethPrice.toFixed(2)}`}
+            />
+          </Section>
         </div>
       )}
     </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <div className={styles.subContainer}>
+      <div className={styles.sectionTitle}>{title}</div>
+      <dl className={styles.dl}>{children}</dl>
+    </div>
+  );
+}
+
+function Row({ label, value }) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- query v2 user endpoint and map reviews/vouches into structured state
- render avatar, names, review counts, vouch totals and ETH price
- expose helper wrappers that unwrap API `data` fields and wire home page to display them
- display main stats and vouches received on home user card

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68904022f5d483219e17c9a4dd32bad8