### PR TITLE
style: apply glass CRT theme to profile card

### DIFF
--- a/components/EthosProfileCard.jsx
+++ b/components/EthosProfileCard.jsx
@@ -132,7 +132,7 @@ export default function EthosProfileCard() {
       {data && (
         <div className={styles.card}>
           {/* Header */}
-          <div className={styles.header}>
+          <div className={styles.headerContainer}>
             {data.avatarUrl && (
               <img
                 src={data.avatarUrl}
@@ -140,8 +140,8 @@ export default function EthosProfileCard() {
                 className={styles.avatar}
               />
             )}
-            <div>
-              <h2>{data.displayName}</h2>
+            <div className={styles.nameBlock}>
+              <h2 className={styles.displayName}>{data.displayName}</h2>
               <div className={styles.handle}>@{data.username}</div>
             </div>
           </div>

--- a/components/EthosProfileCard.module.css
+++ b/components/EthosProfileCard.module.css
@@ -1,88 +1,159 @@
+:root {
+  --crt-bg-dark: #001400;
+  --crt-bg-light: rgba(0, 20, 0, 0.6);
+  --glass-light: rgba(255, 255, 255, 0.06);
+  --glass-border: rgba(255, 255, 255, 0.18);
+  --neon-green: #39ff14;
+  --neon-cyan: #00eaff;
+  --neon-magenta: #ff00e1;
+  --text-crt: #39ff14;
+}
+
+/* Wrapper */
 .wrapper {
-  position: relative;
-  max-width: 640px;
-  margin: 2rem auto;
-  font-family: sans-serif;
+  background: radial-gradient(circle at top left, #111, var(--crt-bg-dark));
+  min-height: 100vh;
+  padding: 2rem;
+  font-family: 'Courier New', monospace;
+  color: var(--text-crt);
 }
-.title {
-  text-align: center;
-  margin-bottom: 1rem;
-}
+
+/* Search Bar */
 .searchBar {
   display: flex;
-  justify-content: center;
   gap: 0.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
-.input {
+.searchBar input {
   flex: 1;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  background: var(--glass-light);
+  border: 1px solid var(--glass-border);
+  border-radius: 9999px;
+  color: var(--text-crt);
+  font-size: 1rem;
 }
-.button {
-  padding: 0.5rem 1rem;
-  background: #0ea5e9;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-}
-.button:disabled {
+.searchBar input::placeholder {
+  color: var(--neon-green);
   opacity: 0.6;
+}
+.searchBar button {
+  padding: 0.6rem 1.2rem;
+  background: var(--glass-light);
+  border: 1px solid var(--neon-green);
+  border-radius: 9999px;
+  color: var(--neon-green);
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+.searchBar button:hover:not(:disabled) {
+  background: rgba(57, 255, 20, 0.1);
+  transform: translateY(-1px);
+}
+.searchBar button:disabled {
+  opacity: 0.4;
   cursor: not-allowed;
 }
-.loadingContainer {
+
+/* Card Container + Scanlines */
+.card {
+  position: relative;
+  background: var(--glass-light);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: 24px;
+  box-shadow: 0 8px 32px rgba(57, 255, 20, 0.2);
+  padding: 2rem;
+  margin: auto;
+  max-width: 600px;
+  overflow: hidden;
+}
+.card::after {
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 4px;
-}
-.loadingBar {
-  height: 4px;
-  background: repeating-linear-gradient(
-    to right,
-    #0ea5e9 0 10px,
-    #38bdf8 10px 20px
+  right: 0;
+  bottom: 0;
+  background-image: repeating-linear-gradient(
+    rgba(0, 0, 0, 0.05) 0 1px,
+    transparent 1px 2px
   );
-  width: 0;
-  transition: width 0.2s ease;
+  pointer-events: none;
 }
-.card {
-  background: #e0f2fe;
-  border-radius: 12px;
-  padding: 1rem;
-}
-.header {
+
+/* Header Container */
+.headerContainer {
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 1rem;
+  background: var(--glass-light);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  padding: 1rem;
+  margin-bottom: 2rem;
 }
 .avatar {
-  width: 64px;
-  height: 64px;
+  width: 80px;
+  height: 80px;
   border-radius: 50%;
+  border: 2px solid var(--neon-green);
   object-fit: cover;
+  transition: transform 0.2s;
 }
+.avatar:hover {
+  transform: scale(1.1);
+}
+.nameBlock {
+  display: flex;
+  flex-direction: column;
+}
+.displayName {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 0;
+  color: var(--neon-cyan);
+}
+.handle {
+  font-size: 1rem;
+  opacity: 0.8;
+  color: var(--neon-green);
+  margin-top: 0.25rem;
+}
+
+/* Sections */
 .section {
-  margin-top: 1rem;
+  position: relative;
+  margin-bottom: 1.5rem;
+  background: var(--glass-light);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  padding: 1.25rem;
+  transition: background 0.2s;
+}
+.section:hover {
+  background: rgba(255, 255, 255, 0.12);
 }
 .sectionTitle {
+  font-size: 1.125rem;
   font-weight: bold;
+  color: var(--neon-magenta);
   text-align: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
 }
 .row {
   display: grid;
-  grid-template-columns: 140px 1fr;
-  column-gap: 0.5rem;
-  margin-bottom: 0.25rem;
+  grid-template-columns: auto 1fr;
+  column-gap: 1rem;
+  row-gap: 0.5rem;
+  align-items: center;
 }
 dt {
   font-weight: bold;
+  color: var(--neon-green);
 }
 dd {
   margin: 0;
+  color: var(--text-crt);
 }


### PR DESCRIPTION
## Summary
- refactor EthosProfileCard styles to glass CRT with neon palette
- add scanline overlay and rounded containers
- align avatar and username inside centered header section
- rename header class and use nameBlock/displayName styles
- adjust CRT color palette and related effects

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68906319126083218078cd19ab925e50