### PR TITLE
refactor: dedupe shared css classes

### DIFF
--- a/cleanup-css.js
+++ b/cleanup-css.js
@@ -1,0 +1,85 @@
+/*
+You have two CSS-Module files in a Next.js project:
+    – components/EthosProfileCard.module.css
+    – styles/Home.module.css
+
+  1. Parse both files and identify any class selectors that are defined in both (e.g. .avatar, .username, etc.).
+  2. For each duplicate:
+     • Choose EthosProfileCard.module.css as the source-of-truth.
+     • Remove the duplicate rule from Home.module.css.
+  3. If there are shared rules you want to keep in both, extract them into a new Shared.module.css and update both components to import it.
+  4. At the end, ensure:
+     • EthosProfileCard.jsx imports only EthosProfileCard.module.css (plus Shared.module.css if used).
+     • Home.jsx (or Home.module.css) no longer contains any of the unwanted duplicates.
+
+  Generate a Node.js script (using PostCSS or regex) or shell script that automates these steps.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const postcss = require('postcss');
+
+const cardCssPath = path.join(__dirname, 'components', 'EthosProfileCard.module.css');
+const homeCssPath = path.join(__dirname, 'styles', 'Home.module.css');
+const sharedCssPath = path.join(__dirname, 'styles', 'Shared.module.css');
+
+function getClassRules(root) {
+  const map = new Map();
+  root.walkRules(rule => {
+    rule.selectors.forEach(sel => {
+      const match = sel.match(/^\.(\w+)/);
+      if (match) {
+        map.set(match[1], rule);
+      }
+    });
+  });
+  return map;
+}
+
+const cardRoot = postcss.parse(fs.readFileSync(cardCssPath, 'utf8'));
+const homeRoot = postcss.parse(fs.readFileSync(homeCssPath, 'utf8'));
+
+const cardClasses = getClassRules(cardRoot);
+const homeClasses = getClassRules(homeRoot);
+
+const duplicates = [];
+homeClasses.forEach((rule, name) => {
+  if (cardClasses.has(name)) {
+    duplicates.push(name);
+    rule.remove();
+  }
+});
+
+if (duplicates.length) {
+  const sharedRoot = postcss.root();
+  duplicates.forEach(name => {
+    const rule = cardClasses.get(name);
+    sharedRoot.append(rule.clone());
+    rule.remove();
+  });
+
+  fs.writeFileSync(sharedCssPath, sharedRoot.toString());
+  fs.writeFileSync(cardCssPath, cardRoot.toString());
+  fs.writeFileSync(homeCssPath, homeRoot.toString());
+
+  const filesToUpdate = [
+    { file: path.join(__dirname, 'components', 'EthosProfileCard.jsx'), importPath: '../styles/Shared.module.css' },
+    { file: path.join(__dirname, 'pages', 'index.js'), importPath: '../styles/Shared.module.css' }
+  ];
+
+  filesToUpdate.forEach(({ file, importPath }) => {
+    let src = fs.readFileSync(file, 'utf8');
+    if (!src.includes(importPath)) {
+      src = src.replace(/(import .*?\n)/, `$1import sharedStyles from '${importPath}';\n`);
+    }
+    duplicates.forEach(name => {
+      const regex = new RegExp(`styles\\.${name}`, 'g');
+      src = src.replace(regex, `sharedStyles.${name}`);
+    });
+    fs.writeFileSync(file, src);
+  });
+
+  console.log('Moved shared classes:', duplicates.join(', '));
+} else {
+  console.log('No duplicates found.');
+}

--- a/components/EthosProfileCard.jsx
+++ b/components/EthosProfileCard.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import styles from './EthosProfileCard.module.css';
+import sharedStyles from '../styles/Shared.module.css';
 
 export default function EthosProfileCard() {
   const [handle, setHandle] = useState('');
@@ -136,12 +137,12 @@ export default function EthosProfileCard() {
               <img
                 src={data.avatarUrl}
                 alt=""
-                className={styles.avatar}
+                className={sharedStyles.avatar}
               />
             )}
             <div className={styles.nameBlock}>
               <h2 className={styles.displayName}>{data.displayName}</h2>
-              <div className={styles.handle}>@{data.username}</div>
+              <div className={sharedStyles.handle}>@{data.username}</div>
             </div>
           </div>
 
@@ -192,7 +193,7 @@ export default function EthosProfileCard() {
 function Section({ title, children }) {
   return (
     <div className={styles.section}>
-      <div className={styles.sectionTitle}>{title}</div>
+      <div className={sharedStyles.sectionTitle}>{title}</div>
       <dl>{children}</dl>
     </div>
   );

--- a/components/EthosProfileCard.module.css
+++ b/components/EthosProfileCard.module.css
@@ -118,13 +118,7 @@
   padding: 1rem;
   margin-bottom: 2rem;
 }
-.avatar {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  border: 2px solid var(--accent);
-  object-fit: cover;
-}
+
 .nameBlock {
   display: flex;
   flex-direction: column;
@@ -133,10 +127,6 @@
   color: var(--text-primary);
   margin: 0;
   font-size: 1.5rem;
-}
-.handle {
-  color: var(--text-secondary);
-  margin-top: 0.25rem;
 }
 
 /* Sections */
@@ -154,13 +144,6 @@
   background: rgba(255, 255, 255, 0.12);
   background: rgba(44, 26, 26, 0.603);
   background: rgba(63, 169, 245, 0.05);
-}
-.sectionTitle {
-  font-size: 1.125rem;
-  font-weight: bold;
-  color: var(--accent);
-  text-align: center;
-  margin-bottom: 1rem;
 }
 
 /* Data Rows */

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import {
   fetchUserAddresses,
 } from '../lib/ethos';
 import styles from '../styles/Home.module.css';
+import sharedStyles from '../styles/Shared.module.css';
 
 export default function Home() {
   const [username, setUsername] = useState('');
@@ -72,12 +73,12 @@ export default function Home() {
       {error && <div className={styles.error}>{error}</div>}
       {userData && (
         <div className={styles.userCard}>
-          <img src={userData.avatarUrl} alt="" className={styles.avatar} />
+          <img src={userData.avatarUrl} alt="" className={sharedStyles.avatar} />
           <h2 className={styles.name}>{userData.displayName}</h2>
-          <p className={styles.handle}>@{userData.username}</p>
+          <p className={sharedStyles.handle}>@{userData.username}</p>
 
           <div className={styles.subContainer}>
-            <div className={styles.sectionTitle}>Main Stats</div>
+            <div className={sharedStyles.sectionTitle}>Main Stats</div>
             <dl className={styles.dl}>
               <dt>ID</dt><dd>{userData.id}</dd>
               <dt>Profile ID</dt><dd>{userData.profileId}</dd>
@@ -114,7 +115,7 @@ export default function Home() {
           </Section>
 
           <div className={styles.subContainer}>
-            <div className={styles.sectionTitle}>Vouches Received</div>
+            <div className={sharedStyles.sectionTitle}>Vouches Received</div>
             <dl className={styles.dl}>
               <dt>Count</dt>
               <dd>{vouchReceived.count}</dd>
@@ -142,7 +143,7 @@ export default function Home() {
 function Section({ title, children }) {
   return (
     <div className={styles.subContainer}>
-      <div className={styles.sectionTitle}>{title}</div>
+      <div className={sharedStyles.sectionTitle}>{title}</div>
       <dl className={styles.dl}>{children}</dl>
     </div>
   );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -72,21 +72,9 @@
   margin-bottom: 1rem;
 }
 
-.avatar {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255, 255, 255, 0.6);
-}
-
 .name {
   font-size: 1.5rem;
   font-weight: 600;
-}
-
-.handle {
-  color: #555;
 }
 
 .subContainer {
@@ -94,12 +82,6 @@
   border-radius: 12px;
   padding: 0.75rem;
   margin-top: 0.75rem;
-}
-
-.sectionTitle {
-  font-weight: 600;
-  text-align: center;
-  margin-bottom: 0.5rem;
 }
 
 .dl {

--- a/styles/Shared.module.css
+++ b/styles/Shared.module.css
@@ -1,0 +1,20 @@
+.avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  border: 2px solid var(--accent);
+  object-fit: cover;
+}
+
+.handle {
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+.sectionTitle {
+  font-size: 1.125rem;
+  font-weight: bold;
+  color: var(--accent);
+  text-align: center;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- move duplicated selectors to new Shared.module.css
- update EthosProfileCard and Home page to consume shared styles
- add cleanup-css.js script to automate future dedupe

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891a0d1c37c83219e4d9a54966bc420